### PR TITLE
Fix to better handle comments in some gcode.

### DIFF
--- a/gcodeParser.py
+++ b/gcodeParser.py
@@ -52,6 +52,7 @@ class GcodeParser:
 			bits = args.split()
 			for bit in bits:
 				letter = bit[0]
+				if letter == '(': return dic
 				coord = float(bit[1:])
 				dic[letter] = coord
 		return dic


### PR DESCRIPTION
Eg: I have slic3r-created GCode that includes these lines:
...
(***\* begin homing ***_)
G162 X Y F2500 (home XY axes maximum)
G161 Z F1100 (home Z axis minimum)
G92 Z-5 (set Z to -5)
G1 Z0.0 (move Z to "0")
G161 Z F100 (home Z axis minimum)
M132 X Y Z A B (Recall stored home offsets for XYZAB axis)
(**_\* end homing ****)

When parsing G92 Z-5 (set Z to -5) I see:
ValueError: could not convert string to float: set

It's trying to parse the comment.  Why this is different from previous lines, I'm not sure but this fix helps parse this file.
